### PR TITLE
Skip the tests that only work with the testbed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
       run: |
         source $CONDA/etc/profile.d/conda.sh
         conda install conda conda-build --yes
-        conda build --no-test conda-recipe
+        conda build conda-recipe
         mv $CONDA/conda-bld .
     - name: Upload the build artifact
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -39,7 +39,8 @@ test:
   commands:
     - pip check
     - python -m nb_conda_kernels list
-    - python -m pytest -v --cov=nb_conda_kernels tests
+    # Skips any tests that assume the existence of the testbed
+    - python -m pytest -v -m "not testbed" --cov=nb_conda_kernels tests
 
 about:
   home: https://github.com/Anaconda-Platform/nb_conda_kernels

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,6 +27,7 @@ def print(x):
     sys.stdout.flush()
 
 
+@pytest.mark.testbed
 def test_configuration():
     print('\nConda configuration')
     print('-------------------')
@@ -169,6 +170,7 @@ def test_kernelspec_path(tmp_path, kernelspec_path, user, prefix, expected):
                 assert call_[1]["prefix"] ==prefix
 
 
+@pytest.mark.testbed
 @pytest.mark.parametrize("kernelspec_path", ["", None])
 def test_install_kernelspec(tmp_path, kernelspec_path):
     config = Config({"CondaKernelSpecManager": {"kernelspec_path": kernelspec_path}})


### PR DESCRIPTION
At least one of the tests requires the existence of the testbed. But we'd like to be able to run as many tests as possible from within the conda build itself. To that end I'm marking testbed-dependent tests with `pytest.mark.testbed`.

The two tests are:
- `test_config.py/test_configuration`: this test is designed to verify that the testbed contains a proper mix of kernel installation scenarios.
- `test_config.py/test_install_kernelspec`: this test will fail unless there is at least one kernel installed outside of the conda-build environment.

Because the CI _does_ exercise these tests fully, we are safe to skip them in the recipe build.

In order to test this, we've removed the `--no-test` option in the `build` stage.